### PR TITLE
Update psy/psysh version and allow minor version changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "psy/psysh": "~0.1.8"
+        "psy/psysh": "~0.4"
     },
     "bin": ["bin/symfony-repl"]
 }


### PR DESCRIPTION
The psy/psysh version 0.1.8 is out of date, and ~0.1.8 only allows up to 0.1.12.

Version 0.4.4 is available and does not break backwards compatibility.

This change allows for version 0.4.4 to be installed and allows for minor versions to be installed (0.5, 0.6, etc.) going forward.
