### PR TITLE
Added support for Symfony 3 and global Composer usage

### DIFF
--- a/bin/symfony-repl
+++ b/bin/symfony-repl
@@ -3,14 +3,34 @@
 
 $root = getcwd();
 
-require_once $root.'/app/bootstrap.php.cache';
-require_once $root.'/app/AppKernel.php';
+require_once $root . '/app/autoload.php';
 
-use Psy\Shell;
+$autoloaders = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+];
+
+foreach ($autoloaders as $autoloader) {
+    if (file_exists($autoloader)) {
+        require_once $autoloader;
+    }
+}
+
+$bootstrap = $root . '/var/bootstrap.php.cache';
+
+if (!file_exists($bootstrap)) {
+    $bootstrap = $root . '/app/bootstrap.php.cache';
+}
+
+require_once $bootstrap;
+require_once $root . '/app/AppKernel.php';
 
 $kernel = new AppKernel('dev', true);
 $kernel->loadClassCache();
 $kernel->boot();
-$kernel->getContainer()->get('cache_clearer')->clear($kernel->getCacheDir());
 
-extract(Shell::debug(array('kernel' => $kernel)));
+$container = $kernel->getContainer();
+$doctrine = $container->get('doctrine');
+$container->get('cache_clearer')->clear($kernel->getCacheDir());
+
+extract(Psy\Shell::debug(compact('kernel', 'container', 'doctrine')));


### PR DESCRIPTION
This commit introduces support for Symfony 3 and enables `symfony-repl` to be used globally (i.e., after `composer global require luxifer/symfony-repl dev-master`).

Additionally, it introduces two new variables into the initial scope of the REPL:

- `$container` - the Symfony service container.
- `$doctrine` - the Doctrine registry.

BC is preserved (to best of knowledge).