### PR TITLE
Prevent debug context being shown

### DIFF
--- a/bin/symfony-repl
+++ b/bin/symfony-repl
@@ -33,4 +33,6 @@ $container = $kernel->getContainer();
 $doctrine = $container->get('doctrine');
 $container->get('cache_clearer')->clear($kernel->getCacheDir());
 
-extract(Psy\Shell::debug(compact('kernel', 'container', 'doctrine')));
+$sh = new \Psy\Shell();
+$sh->setScopeVariables(compact('kernel', 'container', 'doctrine'));
+$sh->run();


### PR DESCRIPTION
A recent version of PsySH outputs context when you call `\Psy\Shell::debug(...)`:

```
$ symfony-repl

Psy Shell v0.8.6 (PHP 7.0.17 — cli) by Justin Hileman
    34| $container->get('cache_clearer')->clear($kernel->getCacheDir());
    35|
  > 36| extract(Psy\Shell::debug(compact('kernel', 'container', 'doctrine')));
    37|

>>>
```

This commit reproduces the procedure in `debug` but without the context.