### PR TITLE
Add Symfony 3.3 support

### DIFF
--- a/bin/symfony-repl
+++ b/bin/symfony-repl
@@ -3,9 +3,9 @@
 
 $root = getcwd();
 
-require_once $root . '/app/autoload.php';
-
 $autoloaders = [
+    $root . '/app/autoload.php',
+    $root . '/vendor/autoload.php',
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../autoload.php',
 ];


### PR DESCRIPTION
`app/autoload.php` is removed from the Symfony standard edition in symfony/symfony-standard#1056, and `vendor/autoload.php` is used instead. This change should ensure that the correct autoloader is included in a backwards-compatible manner.